### PR TITLE
Ignore one-way paths when finding shortest path

### DIFF
--- a/src/main/java/mudmap2/backend/World.java
+++ b/src/main/java/mudmap2/backend/World.java
@@ -582,7 +582,7 @@ public class World implements BreadthSearchGraph {
 
             for(Path pa: v.getPaths()){
                 Place vi = pa.getOtherPlace(v);
-                if(!vi.getBreadthSearchData().marked && vi != v){
+                if(!vi.getBreadthSearchData().marked && vi != v && !pa.getExit(v).equals("-")){
                     vi.getBreadthSearchData().marked = true;
                     vi.getBreadthSearchData().predecessor = v;
                     queue.addLast(vi);


### PR DESCRIPTION
Skips one-way exits, so the rooms they lead to are not added to the queue of rooms to visit. This is a partial fix for #46 .